### PR TITLE
Sort the projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tailwindcss/vite": "^4.1.13",
     "astro": "^5.14.1",
     "remark-github": "^12.0.0",
+    "sharp": "^0.34.4",
     "tailwindcss": "^4.1.13"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       remark-github:
         specifier: ^12.0.0
         version: 12.0.0
+      sharp:
+        specifier: ^0.34.4
+        version: 0.34.4
       tailwindcss:
         specifier: ^4.1.13
         version: 4.1.13
@@ -2130,8 +2133,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.10':
     optional: true
 
-  '@img/colour@1.0.0':
-    optional: true
+  '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.4':
     optionalDependencies:
@@ -3754,7 +3756,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.4
       '@img/sharp-win32-ia32': 0.34.4
       '@img/sharp-win32-x64': 0.34.4
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,25 @@ import RootLayout from "~layouts/RootLayout.astro";
 import FolderIcon from "~assets/folder.webp";
 import { Image } from "astro:assets";
 
-const projects = await getCollection("projects");
+const projectsRaw = await getCollection("projects");
+const devlogs = await getCollection("devlogs");
+
+const latestDates = new Map();
+
+for (const log of devlogs) {
+  const currentLatest = latestDates.get(log.data.project.id);
+
+  if (!currentLatest || log.data.date > currentLatest) {
+    latestDates.set(log.data.project.id, log.data.date);
+  }
+}
+
+const projects = projectsRaw.sort((a, b) => {
+  const dateA = latestDates.get(a.id) ?? -Infinity;
+  const dateB = latestDates.get(b.id) ?? -Infinity;
+
+  return dateB - dateA;
+});
 ---
 
 <RootLayout>


### PR DESCRIPTION
The project with the latest devlog should always appear on top

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Home page now includes devlogs and sorts projects by the most recent devlog, highlighting the latest activity.

- Chores
  - Added a new dependency to the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->