### PR TITLE
Create devlog page layout

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,7 +27,7 @@ export default defineConfig({
       },
       wrap: true,
     },
-    remarkPlugins: [remarkGithub],
+    remarkPlugins: [[remarkGithub, { repository: "kkrishguptaa/artemis" }]],
   },
 
   experimental: {

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -8,6 +8,7 @@ export interface Props {
     text: string;
     href: string;
     external?: boolean;
+    active?: boolean;
   }>;
 }
 
@@ -75,7 +76,7 @@ const { header, items } = Astro.props;
             <a
               href={item.href}
               target={item.external ? "_blank" : undefined}
-              class="block hover:bg-black/5 hover:dark:bg-white/5 hover:underline underline-offset-4 px-6 py-4 transition-colors"
+              class={`block hover:bg-black/5 hover:dark:bg-white/5 hover:underline underline-offset-4 px-6 py-4 transition-colors ${item.active ? "bg-black/5 dark:bg-white/5 font-semibold" : "font-normal"}`}
               title={item.text}
             >
               {item.text.toLocaleLowerCase().replace(/\s+/g, "-")}.md

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,7 +2,7 @@ import { defineCollection, reference, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 
 const projects = defineCollection({
-  loader: glob({ base: './src/content/projects', pattern: ['**/*.{md,yaml}'] }),
+  loader: glob({ base: './src/content/projects', pattern: '*.{md,yaml}' }),
 
   schema: () =>
     z.object({
@@ -27,7 +27,7 @@ const projects = defineCollection({
 });
 
 const devlogs = defineCollection({
-  loader: glob({ base: './src/content/devlogs', pattern: '**/*.{md}' }),
+  loader: glob({ base: './src/content/devlogs', pattern: '**/*.md' }),
 
   schema: () =>
     z.object({

--- a/src/content/devlogs/apollo/init.md
+++ b/src/content/devlogs/apollo/init.md
@@ -1,0 +1,9 @@
+---
+title: Introduction
+description: The introduction to how Apollo came into being.
+date: 2025-10-03
+project: apollo
+---
+
+hi
+yo man what

--- a/src/content/projects/apollo.md
+++ b/src/content/projects/apollo.md
@@ -1,0 +1,8 @@
+---
+name: Apollo
+description: Astro Blog built for Speed ⚡️
+website: https://blog.krishg.com
+git: apollo
+---
+
+Apollo is a tiny blog built with Astro. The goal is to have a small tiny bundle size, near zero javascript, and an elegant design. The blogs are supposed to be markdown!

--- a/src/content/projects/apollo.yaml
+++ b/src/content/projects/apollo.yaml
@@ -1,4 +1,0 @@
-name: Apollo
-description: Static Technical Blog
-website: https://blog.krishg.com
-git: apollo

--- a/src/layouts/DevlogLayout.astro
+++ b/src/layouts/DevlogLayout.astro
@@ -2,13 +2,17 @@
 import Sidebar from "~components/Sidebar.astro";
 import RootLayout from "./RootLayout.astro";
 import type { CollectionEntry } from "astro:content";
+import { render } from "astro:content";
 
 export interface Props {
   project: CollectionEntry<"projects">;
   devlogs: CollectionEntry<"devlogs">[];
+  devlog: CollectionEntry<"devlogs">;
 }
 
-const { project, devlogs } = Astro.props;
+const { project, devlogs, devlog } = Astro.props;
+
+const { Content } = await render(devlog);
 ---
 
 <RootLayout head={{}}>
@@ -24,12 +28,15 @@ const { project, devlogs } = Astro.props;
           project.id + "/" + log.id.split("/").pop()!,
           Astro.site
         ).toString(),
+        active: log.id === devlog.id,
       }))}
     />
     <article
       class="flex-1 overflow-y-auto p-8 prose dark:prose-invert prose-hr:border-black/20 dark:prose-hr:border-white/20 prose-a:underline prose-a:underline-offset-4 mx-auto"
     >
-      <slot />
+      <h1>{devlog.data.title}</h1>
+      <hr class="mt-1 mb-4" />
+      <Content />
     </article>
   </main>
 </RootLayout>

--- a/src/pages/[project]/[devlog].astro
+++ b/src/pages/[project]/[devlog].astro
@@ -1,0 +1,29 @@
+---
+import { getEntry } from "astro:content";
+import { getCollection } from "astro:content";
+import DevlogLayout from "~layouts/DevlogLayout.astro";
+
+export async function getStaticPaths() {
+  const devlogs = await getCollection("devlogs");
+
+  return await Promise.all(
+    devlogs.map(async (devlog) => ({
+      params: {
+        project: devlog.data.project.id,
+        devlog: devlog.id.split("/").pop()!,
+      },
+      props: {
+        project: await getEntry("projects", devlog.data.project.id)!,
+        devlog,
+        devlogs: devlogs.filter(
+          (log) => log.data.project.id === devlog.data.project.id
+        ),
+      },
+    }))
+  );
+}
+
+const { project, devlogs, devlog } = Astro.props;
+---
+
+<DevlogLayout project={project} devlogs={devlogs} devlog={devlog} />

--- a/src/pages/[project]/index.astro
+++ b/src/pages/[project]/index.astro
@@ -1,4 +1,5 @@
 ---
+import { render } from "astro:content";
 import { getCollection } from "astro:content";
 import ProjectLayout from "~layouts/ProjectLayout.astro";
 
@@ -17,6 +18,83 @@ const devlogs = await getCollection(
   "devlogs",
   (log) => log.data.project.id === project.id
 );
+
+const { Content } = await render(project);
 ---
 
-<ProjectLayout project={project} devlogs={devlogs}>Hi</ProjectLayout>
+<ProjectLayout project={project} devlogs={devlogs}>
+  <h1>{project.data.name}</h1>
+  <p>
+    {project.data.description}
+  </p>
+  <p class="flex gap-2">
+    {
+      project.data.website && (
+        <a
+          href={project.data.website}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span>Website</span>
+        </a>
+      )
+    }
+    {project.data.website && <span>•</span>}
+    <a
+      href={new URL(
+        project.data.git.owner + "/" + project.data.git.repo,
+        project.data.git.host
+      )}
+      class="underline underline-offset-4"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span>Source</span>
+    </a>
+  </p>
+  <hr />
+
+  {devlogs.length > 0 && <h2>Devlogs</h2>}
+  {
+    devlogs.length > 0 ? (
+      <ul class="pl-0 space-y-0.5">
+        {devlogs.map((log) => (
+          <li class="flex items-baseline pl-0 gap-4 flex-wrap">
+            <a
+              href={new URL(
+                project.id + "/" + log.id.split("/").pop()!,
+                Astro.site
+              ).toString()}
+              class="underline underline-offset-4"
+            >
+              {log.data.title}
+            </a>
+            <span class="flex-1 text-right text-sm text-black/70 dark:text-white/70">
+              {new Date(log.data.date).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </span>
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <p>
+        It seems like Krish still hasn't written devlogs for this project. Bug
+        him on{" "}
+        <a
+          href="https://twitter.com/kkrishguptaa"
+          class="underline underline-offset-4"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Twitter.
+        </a>
+      </p>
+    )
+  }
+  <hr />
+  {project.body && <h2>About this project</h2>}
+  {project.body && <Content />}
+</ProjectLayout>


### PR DESCRIPTION
Now all that remains is to write like a hundred devlogs are debug lmao

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced dedicated devlog pages per project with a new layout.
  - Project pages now list devlogs with dates and improved project details (website/source links).
  - Sidebar supports active item highlighting for better navigation.
- Documentation
  - Added “Apollo” project page and initial devlog; removed legacy YAML entry.
- Style
  - Enhanced article typography and spacing for improved readability.
- Chores
  - Updated markdown processing plugin configuration.
  - Refined content loading patterns to focus on top-level project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->